### PR TITLE
Add Robot health

### DIFF
--- a/engine/arena.py
+++ b/engine/arena.py
@@ -165,6 +165,24 @@ class Arena:
 
         return quadtree
 
+    def __render_scene(self, quadtree: Quadtree):
+        """Renders the Arena onto self.__surface."""
+        # Draw updated entities onto the surface
+        for entity in self.__entities:
+            entity.render(self.__surface)
+        for entity in self.__entities:
+            entity.post_render(self.__surface)
+
+        # Draw hitboxes
+        if self.show_hitboxes:
+            for entity in self.__entities:
+                pygame.draw.lines(self.__surface, "#FF0000", True,
+                                  entity.absolute_hitbox)
+
+        # Draw quadtree
+        if self.show_quadtree:
+            quadtree.render(self.__surface)
+
     def update(self, dt: float):
         """Updates the state of the arena after time delta `dt`, in seconds."""
         # Fill the screen with a color to wipe away anything from last frame
@@ -186,19 +204,8 @@ class Arena:
         # Filter destroyed entities (yes, again)
         self.__filter_entities()
 
-        # Draw updated entities onto the surface
-        for entity in self.__entities:
-            entity.render(self.__surface)
-
-        # Draw hitboxes
-        if self.show_hitboxes:
-            for entity in self.__entities:
-                pygame.draw.lines(self.__surface, "#FF0000", True,
-                                  entity.absolute_hitbox)
-
-        # Draw quadtree
-        if self.show_quadtree:
-            quadtree.render(self.__surface)
+        # Render the scene
+        self.__render_scene(quadtree)
 
     def run(self):
         """Runs simulation of the Arena."""

--- a/engine/entity/bullet.py
+++ b/engine/entity/bullet.py
@@ -17,6 +17,8 @@ TRAIL_TAIL_COLOR = "#AAAAAA00"
 
 NUM_HITBOX_VERTICES = 3
 
+DAMAGE = 10
+
 
 class Bullet(entity.Entity):
     def __init__(self, position: Vector2, rotation: float,
@@ -53,7 +55,7 @@ class Bullet(entity.Entity):
             return
 
         if type(other) is entity.Robot:
-            other.destroy()
+            other.health -= DAMAGE
             self.destroy()
         elif type(other) is entity.Wall:
             # React to collision

--- a/engine/entity/entity.py
+++ b/engine/entity/entity.py
@@ -93,6 +93,10 @@ class Entity:
         """Renders the entity onto a screen."""
         pass
 
+    def post_render(self, screen: pygame.Surface):
+        """Second stage of rendering, once all entities have rendered."""
+        pass
+
     def destroy(self):
         """Removes the entity from its parent arena."""
         # TODO: Commented out the below assert temporarily, since this method

--- a/engine/entity/robot.py
+++ b/engine/entity/robot.py
@@ -6,6 +6,7 @@ import pygame
 
 import engine.entity as entity
 
+Rect = pygame.Rect
 Vector2 = pygame.Vector2
 
 # Dimensional constants (in pixels)
@@ -28,6 +29,12 @@ TREADS_COLOR = "#888888"            # Color of robot's treads
 TREADS_LINES_COLOR = "#555555"      # Color of lines on robot's treads
 ARROW_COLOR = "#AAAAAA"             # Color of robot front arrow
 
+MAX_HEALTH = 100                    # Default max robot health
+HEALTH_COLOR = "#00FF00"            # Color of available health bar
+HEALTH_DEFICIT_COLOR = "#FF0000"    # Color of deficit in health bar
+HEALTH_BAR_LENGTH = 160             # Length of health bar
+HEALTH_BAR_WIDTH = 20               # Width of health bar
+
 
 class Robot(entity.Entity):
     """Robot entity that can move, turn, and shoot."""
@@ -36,7 +43,7 @@ class Robot(entity.Entity):
 
         self.on_update: Optional[Callback] = None   # Callback on each `update`
 
-        self.health = 100                           # Default max health
+        self.health = MAX_HEALTH                    # Robot health
 
         self.move_power = 0                         # Range: [-1, 1]
         self.turn_power = 0                         # Range: [-1, 1]
@@ -308,6 +315,29 @@ class Robot(entity.Entity):
         # Draw robot head
         pygame.draw.circle(screen, self.head_color, self.position,
                            ROBOT_HEAD_RADIUS)
+
+    def post_render(self, screen: pygame.Surface):
+        # Draw health bar
+        if self.health >= MAX_HEALTH:
+            return
+
+        # Get "radius" of Robot
+        radius = self.hitbox[0].magnitude()
+
+        # Top left position of bars
+        top_left = self.position + Vector2(-HEALTH_BAR_LENGTH / 2, radius)
+
+        # Draw deficit bar
+        pygame.draw.rect(screen, HEALTH_DEFICIT_COLOR,
+                         Rect(top_left, Vector2(HEALTH_BAR_LENGTH,
+                                                HEALTH_BAR_WIDTH)))
+
+        available_length = (self.health / MAX_HEALTH) * HEALTH_BAR_LENGTH
+
+        # Draw available bar
+        pygame.draw.rect(screen, HEALTH_COLOR,
+                         Rect(top_left, Vector2(available_length,
+                                                HEALTH_BAR_WIDTH)))
 
 
 # Callback type for `on_update`

--- a/engine/entity/robot.py
+++ b/engine/entity/robot.py
@@ -77,6 +77,10 @@ class Robot(entity.Entity):
     def health(self, health: float):
         self.__health = max(health, 0)
 
+        # Destroy the robot if it runs out of health
+        if self.__health == 0:
+            self.destroy()
+
     # We separate the `X_power` members into properties with specialized
     # setters so that we can clamp the values between [-1, 1].
     @property

--- a/engine/entity/robot.py
+++ b/engine/entity/robot.py
@@ -36,6 +36,8 @@ class Robot(entity.Entity):
 
         self.on_update: Optional[Callback] = None   # Callback on each `update`
 
+        self.health = 100                           # Default max health
+
         self.move_power = 0                         # Range: [-1, 1]
         self.turn_power = 0                         # Range: [-1, 1]
         self.turret_turn_power = 0                  # Range: [-1, 1]
@@ -65,6 +67,15 @@ class Robot(entity.Entity):
             Vector2(-length / 2, -width / 2),
             Vector2(-length / 2, width / 2)
         ]
+
+    @property
+    def health(self) -> float:
+        """Remaining health points of the Robot."""
+        return self.__health
+
+    @health.setter
+    def health(self, health: float):
+        self.__health = max(health, 0)
 
     # We separate the `X_power` members into properties with specialized
     # setters so that we can clamp the values between [-1, 1].

--- a/engine/entity/robot.py
+++ b/engine/entity/robot.py
@@ -30,10 +30,10 @@ TREADS_LINES_COLOR = "#555555"      # Color of lines on robot's treads
 ARROW_COLOR = "#AAAAAA"             # Color of robot front arrow
 
 MAX_HEALTH = 100                    # Default max robot health
-HEALTH_COLOR = "#00FF00"            # Color of available health bar
-HEALTH_DEFICIT_COLOR = "#FF0000"    # Color of deficit in health bar
-HEALTH_BAR_LENGTH = 160             # Length of health bar
-HEALTH_BAR_WIDTH = 20               # Width of health bar
+HEALTH_COLOR = "#00BB00"            # Color of available health bar
+HEALTH_DEFICIT_COLOR = "#CC0000"    # Color of deficit in health bar
+HEALTH_BAR_LENGTH = 80              # Length of health bar
+HEALTH_BAR_WIDTH = 8                # Width of health bar
 
 
 class Robot(entity.Entity):

--- a/init.py
+++ b/init.py
@@ -12,7 +12,7 @@ from engine import Arena, Robot
 def keyboard_control(robot: Robot):
     """Keyboard control scheme for the user-controlled Robot."""
     keys = pygame.key.get_pressed()
-    robot.move_power = -1 if keys[pygame.K_s] else 1 if keys[pygame.K_w] else 000
+    robot.move_power = -1 if keys[pygame.K_s] else 1 if keys[pygame.K_w] else 0
     robot.turn_power = -1 if keys[pygame.K_a] else 1 if keys[pygame.K_d] else 0
     robot.turret_turn_power = (-1 if keys[pygame.K_q] else 1 if
                                keys[pygame.K_e] else 0)

--- a/init.py
+++ b/init.py
@@ -12,7 +12,7 @@ from engine import Arena, Robot
 def keyboard_control(robot: Robot):
     """Keyboard control scheme for the user-controlled Robot."""
     keys = pygame.key.get_pressed()
-    robot.move_power = -1 if keys[pygame.K_s] else 1 if keys[pygame.K_w] else 0
+    robot.move_power = -1 if keys[pygame.K_s] else 1 if keys[pygame.K_w] else 000
     robot.turn_power = -1 if keys[pygame.K_a] else 1 if keys[pygame.K_d] else 0
     robot.turret_turn_power = (-1 if keys[pygame.K_q] else 1 if
                                keys[pygame.K_e] else 0)


### PR DESCRIPTION
- Adds `Robot.health: float`, a property which represents the `Robot`'s remaining health.
- The default value of `Robot.health` is `100`, as configured through the `MAX_HEALTH` constant.
- Upon turning zero, the `Robot` is destroyed.
- Bullets deal `DAMAGE = 10` of health damage to a `Robot` it collides with.
- Adds `Entity.post_render`, an additional render method used in a second stage of rendering. This is to draw over all other `Entity`s that have already been drawn via `render`.
- Adds `Arena.__render_scene`, a private method which performs both stages of `Entity` rendering as well as optional hitboxes and quadtree.