### PR TITLE
Add coins

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ Run `init.py` in Python. (This is a testing script and will be changed/moved in 
     * **[IMPLEMENTED]** *`Robot` Destruction* - Incorporate health in `Robot` and damage in `Bullet`.
     * *Win Condition* - Destroy the other `Robot`.
     * *Stalemate Condition* - Both `Robot`s are still alive after *n* seconds of simulation.
-    * *Secondary Win Condition* - In case of stalemate, use this condition as a tiebreaker. Some ideas:
-        * *Portion of `Arena` Discovered* - Reward the `Robot` who ventured out the most.
-        * *Coins* - Place `Coin` entities around the `Arena`; whichever `Robot` collects the most wins in case of stalemate.
+    * **[IMPLEMENTED]** *Coins* - Place `Coin` entities around the `Arena`; whichever `Robot` collects the most wins in case of stalemate.
 * `Robot` Programmability
     * **[IMPLEMENTED]** *`Robot` Manipulation* - Expose API to move and turn the `Robot` and shoot `Bullet`s.
     * **[IMPLEMENTED]** *Enemy `Robot` Detection* - Expose API to find the nearest `Robot` to a given `Robot`.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -4,6 +4,7 @@ os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"
 
 from engine.arena import Arena as Arena
 from engine.entity import Bullet as Bullet
+from engine.entity import Coin as Coin
 from engine.entity import Entity as Entity
 from engine.entity import Robot as Robot
 from engine.entity import Wall as Wall

--- a/engine/arena.py
+++ b/engine/arena.py
@@ -235,6 +235,9 @@ class Arena:
 
     def __render_scene(self):
         """Renders the Arena onto self.__surface."""
+        # Clear screen with grass color
+        self.__surface.fill(GRASS_COLOR)
+
         # Draw updated entities onto the surface
         for entity in self.__entities:
             entity.render(self.__surface)
@@ -299,7 +302,6 @@ class Arena:
 
     def update(self, dt: float):
         """Updates the state of the arena after time delta `dt`, in seconds."""
-        self.__surface.fill(GRASS_COLOR)
         self.__update_entities(dt)
         self.__filter_entities()
         self.__construct_quadtree()

--- a/engine/arena.py
+++ b/engine/arena.py
@@ -171,6 +171,21 @@ class Arena:
 
         return neighbor
 
+    def nearest_coin(self, robot: Robot) -> Optional[Coin]:
+        """Returns the Coin closest to a Robot."""
+        # Robot.on_update may call this, and the quadtree won't exist on the
+        # first update, so just return None
+        if self.__quadtree is None:
+            return None
+
+        neighbor = self.__quadtree.nearest_neighbor(
+            robot.position,
+            lambda e: type(e) is Coin and e is not robot
+        )
+        assert neighbor is None or type(neighbor) is Coin, "Shouldn't happen"
+
+        return neighbor
+
     def prepare_path_graph(self):
         """
         Prepares the PathfindingGraph for this Arena, based on the Walls it

--- a/engine/entity/__init__.py
+++ b/engine/entity/__init__.py
@@ -4,5 +4,6 @@
 from engine.entity.entity import Entity as Entity
 
 from engine.entity.bullet import Bullet as Bullet
+from engine.entity.coin import Coin as Coin
 from engine.entity.robot import Robot as Robot
 from engine.entity.wall import Wall as Wall

--- a/engine/entity/coin.py
+++ b/engine/entity/coin.py
@@ -32,7 +32,8 @@ class Coin(entity.Entity):
 
     def on_collide(self, other: entity.Entity, _: Vector2):
         if type(other) is entity.Robot:
-            # Destroy upon colliding with a Robot
+            # Award coin and destroy Coin
+            other.coins += 1
             self.destroy()
 
     def render(self, screen: pygame.Surface):

--- a/engine/entity/coin.py
+++ b/engine/entity/coin.py
@@ -19,11 +19,13 @@ class Coin(entity.Entity):
         super().__init__()
         self.position = position
 
+    @property
     def hitbox(self) -> list[Vector2]:
         dangle = 2 * math.pi / NUM_HITBOX_VERTICES
         return [Vector2(COIN_RADIUS, 0).rotate_rad(i * dangle)
                 for i in range(NUM_HITBOX_VERTICES)]
 
+    @property
     def reacts_to_collisions(self) -> bool:
         # Prevent collision reactions
         return False

--- a/engine/entity/coin.py
+++ b/engine/entity/coin.py
@@ -4,11 +4,14 @@ import pygame
 
 import engine.entity as entity
 
+Surface = pygame.Surface
 Vector2 = pygame.Vector2
 
 NUM_HITBOX_VERTICES = 3
 COIN_RADIUS = 24
-COIN_COLOR = "#FFFF00"
+COIN_COLOR = "#FFCD38"
+COIN_BORDER_THICKNESS = 6
+COIN_BORDER_COLOR = "#C79B22"
 
 
 class Coin(entity.Entity):
@@ -19,6 +22,7 @@ class Coin(entity.Entity):
     def __init__(self, position: Vector2):
         super().__init__()
         self.position = position
+        self.__animation_alpha = 0      # Animation progress in [0, 1)
 
     @property
     def hitbox(self) -> list[Vector2]:
@@ -39,5 +43,24 @@ class Coin(entity.Entity):
         other.coins += 1
         self.destroy()
 
-    def render(self, screen: pygame.Surface):
-        pygame.draw.circle(screen, COIN_COLOR, self.position, COIN_RADIUS)
+    def update(self, dt: float):
+        self.__animation_alpha += dt
+        self.__animation_alpha %= 1
+
+    def render(self, screen: Surface):
+        surface_size = Vector2(COIN_RADIUS * 2, COIN_RADIUS * 2)
+        coin_surface = Surface(surface_size, flags=pygame.SRCALPHA)
+
+        pygame.draw.circle(coin_surface, COIN_BORDER_COLOR, surface_size / 2,
+                           COIN_RADIUS)
+
+        inner_radius = COIN_RADIUS - COIN_BORDER_THICKNESS
+        pygame.draw.circle(coin_surface, COIN_COLOR, surface_size / 2,
+                           inner_radius)
+
+        angle = self.__animation_alpha * 2 * math.pi
+        coin_width = COIN_RADIUS * abs(math.cos(angle)) * 2
+        coin_size = Vector2(coin_width, COIN_RADIUS * 2)
+        coin_surface = pygame.transform.smoothscale(coin_surface, coin_size)
+
+        screen.blit(coin_surface, self.position - coin_size / 2)

--- a/engine/entity/coin.py
+++ b/engine/entity/coin.py
@@ -24,5 +24,14 @@ class Coin(entity.Entity):
         return [Vector2(COIN_RADIUS, 0).rotate_rad(i * dangle)
                 for i in range(NUM_HITBOX_VERTICES)]
 
+    def reacts_to_collisions(self) -> bool:
+        # Prevent collision reactions
+        return False
+
+    def on_collide(self, other: entity.Entity, _: Vector2):
+        if type(other) is entity.Robot:
+            # Destroy upon colliding with a Robot
+            self.destroy()
+
     def render(self, screen: pygame.Surface):
         pygame.draw.circle(screen, "#FFFF00", self.position, COIN_RADIUS)

--- a/engine/entity/coin.py
+++ b/engine/entity/coin.py
@@ -31,10 +31,12 @@ class Coin(entity.Entity):
         return False
 
     def on_collide(self, other: entity.Entity, _: Vector2):
-        if type(other) is entity.Robot:
-            # Award coin and destroy Coin
-            other.coins += 1
-            self.destroy()
+        # Only award coin if it's alive and it touches a Robot
+        if self.arena is None or type(other) is not entity.Robot:
+            return
+        # Award coin and destroy Coin
+        other.coins += 1
+        self.destroy()
 
     def render(self, screen: pygame.Surface):
         pygame.draw.circle(screen, "#FFFF00", self.position, COIN_RADIUS)

--- a/engine/entity/coin.py
+++ b/engine/entity/coin.py
@@ -8,6 +8,7 @@ Vector2 = pygame.Vector2
 
 NUM_HITBOX_VERTICES = 3
 COIN_RADIUS = 24
+COIN_COLOR = "#FFFF00"
 
 
 class Coin(entity.Entity):
@@ -39,4 +40,4 @@ class Coin(entity.Entity):
         self.destroy()
 
     def render(self, screen: pygame.Surface):
-        pygame.draw.circle(screen, "#FFFF00", self.position, COIN_RADIUS)
+        pygame.draw.circle(screen, COIN_COLOR, self.position, COIN_RADIUS)

--- a/engine/entity/coin.py
+++ b/engine/entity/coin.py
@@ -1,0 +1,28 @@
+import math
+
+import pygame
+
+import engine.entity as entity
+
+Vector2 = pygame.Vector2
+
+NUM_HITBOX_VERTICES = 3
+COIN_RADIUS = 8
+
+
+class Coin(entity.Entity):
+    """
+    Coin spread throughout the map which Robots collect for their secondary
+    objective.
+    """
+    def __init__(self, position: Vector2):
+        super().__init__()
+        self.position = position
+
+    def hitbox(self) -> list[Vector2]:
+        dangle = 2 * math.pi / NUM_HITBOX_VERTICES
+        return [Vector2(COIN_RADIUS, 0).rotate_rad(i * dangle)
+                for i in range(NUM_HITBOX_VERTICES)]
+
+    def render(self, screen: pygame.Surface):
+        pygame.draw.circle(screen, "#FFFF00", self.position, COIN_RADIUS)

--- a/engine/entity/coin.py
+++ b/engine/entity/coin.py
@@ -7,7 +7,7 @@ import engine.entity as entity
 Vector2 = pygame.Vector2
 
 NUM_HITBOX_VERTICES = 3
-COIN_RADIUS = 8
+COIN_RADIUS = 24
 
 
 class Coin(entity.Entity):

--- a/engine/entity/robot.py
+++ b/engine/entity/robot.py
@@ -296,7 +296,12 @@ class Robot(entity.Entity):
 
     def update(self, dt: float):
         if self.on_update is not None:
+            # Reset power values, since on_update will set them
+            self.move_power = 0
+            self.turn_power = 0
+            self.turret_turn_power = 0
             self.on_update(self, dt)
+
         self.__move(dt)
         self.__turn(dt)
         self.__turn_turret(dt)

--- a/engine/entity/robot.py
+++ b/engine/entity/robot.py
@@ -73,6 +73,8 @@ class Robot(entity.Entity):
 
         self.turret_rotation = 0                    # Turret rotation (radians)
 
+        self.coins = 0                              # Number of coins collected
+
         self.__move_speed = 300                     # Maximum move speed
         self.__turn_speed = math.pi                 # Maximum turn speed
         self.__turret_turn_speed = 1.5 * math.pi    # Maximum turret turn speed

--- a/engine/entity/robot.py
+++ b/engine/entity/robot.py
@@ -123,6 +123,12 @@ class Robot(entity.Entity):
             return
         return self.arena.nearest_robot(self)
 
+    @property
+    def nearest_coin(self) -> Optional[entity.Coin]:
+        if self.arena is None:
+            return
+        return self.arena.nearest_coin(self)
+
     # We separate the `X_power` members into properties with specialized
     # setters so that we can clamp the values between [-1, 1].
     @property

--- a/engine/entity/robot.py
+++ b/engine/entity/robot.py
@@ -57,8 +57,9 @@ def angle_difference(angle1: float, angle2: float) -> float:
 
 class Robot(entity.Entity):
     """Robot entity that can move, turn, and shoot."""
-    def __init__(self):
+    def __init__(self, name: str):
         super().__init__()
+        self.name = name
 
         self.on_update: Optional[Callback] = None   # Callback on each `update`
 

--- a/engine/pathfinding.py
+++ b/engine/pathfinding.py
@@ -201,6 +201,13 @@ class PathfindingGraph:
 
         return [node.position for node in node_path]
 
+    def get_available_nodes(self) -> list[Vector2]:
+        """Returns positions of all nodes with at least one neighbor."""
+        return [node.position
+                for row in self.__nodes
+                for node in row
+                if len(node.neighbors) > 0]
+
     def render(self, surface: pygame.Surface):
         """Draws the PathfindingGraph onto a surface."""
         for row in self.__nodes:

--- a/init.py
+++ b/init.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
         quit()
 
     # Create the player robot
-    player_robot = Robot()
+    player_robot = Robot("Player")
     player_robot.color = "#0000EE"
     player_robot.head_color = "#0000CC"
     player_robot.on_update = human_controller_factory(arena)
@@ -125,19 +125,19 @@ if __name__ == "__main__":
 
     # These Robots seek the player Robot
     for i in range(1):
-        npc_robot = Robot()
+        npc_robot = Robot(f"NPC {len(robots) + i}")
         npc_robot.on_update = seek_robot_controller_factory(player_robot)
         robots.append(npc_robot)
 
     # These Robots seek the nearest Robot
     for i in range(1):
-        npc_robot = Robot()
+        npc_robot = Robot(f"NPC {len(robots) + i}")
         npc_robot.on_update = seek_nearest_robot_controller
         robots.append(npc_robot)
 
     # These Robots spin, move, and shoot randomly
     for i in range(1):
-        npc_robot = Robot()
+        npc_robot = Robot(f"NPC {len(robots) + i}")
         npc_robot.on_update = spin_controller_factory()
         robots.append(npc_robot)
 
@@ -149,7 +149,7 @@ if __name__ == "__main__":
     arena.show_hitboxes = False
 
     # Shows FPS in the top-left corner of the window.
-    arena.show_fps = False
+    arena.show_fps = True
 
     # Shows the Quadtree; draws small blue circles at each node's region
     # center, draws blue edges between them, and draws blue bounding rectangles

--- a/init.py
+++ b/init.py
@@ -8,6 +8,8 @@ import pygame
 
 from engine import Arena, Robot, ROBOT_RADIUS
 
+Vector2 = pygame.Vector2
+
 
 def human_controller_factory(arena: Arena):
     """Creates a human control scheme for a Robot given an Arena."""
@@ -29,7 +31,7 @@ def human_controller_factory(arena: Arena):
         # Click to test pathfinding (with Arena.show_paths = True)
         down, *_ = pygame.mouse.get_pressed()
         if down:
-            window_point = pygame.Vector2(pygame.mouse.get_pos())
+            window_point = Vector2(pygame.mouse.get_pos())
             arena_point = arena.window_to_arena(window_point)
             # Simply generate the path without using it, for viz purposes
             robot.pathfind(arena_point)
@@ -37,22 +39,15 @@ def human_controller_factory(arena: Arena):
     return human_controller
 
 
-def seek_pathfinding(robot: Robot, enemy: Robot, dt: float) -> bool:
-    """Helper function for moving a Robot towards its enemy via pathfinding."""
-    robot.move_power = 0
-    robot.turn_power = 0
-    robot.turret_turn_power = 0
-
-    if enemy.arena is None:
-        return False
-
-    # Aim towards enemy
-    robot.aim_towards(enemy.position, dt)
-
-    # Figure out path towards enemy
-    path = robot.pathfind(enemy.position)
+def seek_point_pathfinding(robot: Robot, point: Vector2, dt: float) -> bool:
+    """Helper function for moving a Robot towards a point via pathfinding."""
+    # Figure out path towards point
+    path = robot.pathfind(point)
     if path is None:
         return False
+
+    # Add point to path
+    path.append(point)
 
     # Prune nodes until they're at least some distance away
     i = 0
@@ -69,10 +64,22 @@ def seek_pathfinding(robot: Robot, enemy: Robot, dt: float) -> bool:
     return True
 
 
+def seek_enemy_pathfinding(robot: Robot, enemy: Robot, dt: float) -> bool:
+    """Helper function for moving a Robot towards its enemy via pathfinding."""
+    if enemy.arena is None:
+        return False
+
+    # Aim towards enemy
+    robot.aim_towards(enemy.position, dt)
+
+    # Move towards enemy
+    return seek_point_pathfinding(robot, enemy.position, dt)
+
+
 def seek_robot_controller_factory(target: Robot):
     """Creates a control scheme to seek a certain robot with pathfinding."""
     def control(robot: Robot, dt: float):
-        if seek_pathfinding(robot, target, dt):
+        if seek_enemy_pathfinding(robot, target, dt):
             robot.shoot()
 
     return control
@@ -81,13 +88,18 @@ def seek_robot_controller_factory(target: Robot):
 def seek_nearest_robot_controller(robot: Robot, dt: float):
     """Control scheme for seeking the nearest robot with pathfinding."""
     nearest = robot.nearest_robot
-    if nearest is None:
-        robot.move_power = 0
-        robot.turn_power = 0
-        robot.turret_turn_power = 0
-        return
-    if seek_pathfinding(robot, nearest, dt):
+    if nearest is not None and seek_enemy_pathfinding(robot, nearest, dt):
         robot.shoot()
+
+
+def seek_nearest_coin_controller(robot: Robot, dt: float):
+    """Control scheme for seeking the nearest coin with pathfinding."""
+    coin = robot.nearest_coin
+    if coin is None:
+        return
+
+    # Move towards coin
+    seek_point_pathfinding(robot, coin.position, dt)
 
 
 def spin_controller_factory():
@@ -124,20 +136,26 @@ if __name__ == "__main__":
     # number doesn't exceed the spawn count for the map.
 
     # These Robots seek the player Robot
-    for i in range(1):
-        npc_robot = Robot(f"NPC {len(robots) + i}")
+    for i in range(0):
+        npc_robot = Robot(f"NPC {len(robots)}")
         npc_robot.on_update = seek_robot_controller_factory(player_robot)
         robots.append(npc_robot)
 
     # These Robots seek the nearest Robot
     for i in range(1):
-        npc_robot = Robot(f"NPC {len(robots) + i}")
+        npc_robot = Robot(f"NPC {len(robots)}")
         npc_robot.on_update = seek_nearest_robot_controller
         robots.append(npc_robot)
 
+    # These Robots seek the nearest Coin
+    for i in range(2):
+        npc_robot = Robot(f"NPC {len(robots)}")
+        npc_robot.on_update = seek_nearest_coin_controller
+        robots.append(npc_robot)
+
     # These Robots spin, move, and shoot randomly
-    for i in range(1):
-        npc_robot = Robot(f"NPC {len(robots) + i}")
+    for i in range(0):
+        npc_robot = Robot(f"NPC {len(robots)}")
         npc_robot.on_update = spin_controller_factory()
         robots.append(npc_robot)
 


### PR DESCRIPTION
Adds the `Coin` class, which is an `Entity` that represents a collectable coin. Once a `Robot` touches a `Coin`, it adds 1 to its coin score. Coin scores are displayed on the left side of the viewport, and they will be used as a tiebreaker in case of a stalemate. The `Arena` spawns one `Coin` in a random location, and spawns a new one each time it is collected. `Robot`s can now also detect the nearest `Coin`.