### PR TITLE
Optimization pass

### DIFF
--- a/engine/arena.py
+++ b/engine/arena.py
@@ -59,6 +59,9 @@ class Arena:
         self.total_sim_time = 0         # Total simulation time (not elapsed)
         self.is_shrinking = False       # Whether to close walls in over time
 
+        # Whether to use pathfinding over direct paths
+        self.use_pathfinding = True
+
         # Debug settings
         self.show_hitboxes = False
         self.show_fps = False
@@ -282,6 +285,10 @@ class Arena:
         """
         Finds a path between the robot and a provided point, if there is one.
         """
+        # Early exit if not using pathfinding
+        if not self.use_pathfinding:
+            return [point]
+
         assert self.__path_graph is not None, "Path graph should exist"
         path = self.__path_graph.pathfind(robot.position, robot.rotation,
                                           point)

--- a/engine/arena.py
+++ b/engine/arena.py
@@ -15,7 +15,7 @@ from engine.entity.robot import ROBOT_HITBOX_WIDTH
 from engine.map import is_map
 from engine.pathfinding import PathfindingGraph
 from engine.quadtree import Quadtree
-from engine.robotlist import (render_robot_list, WIDTH as ROBOT_LIST_WIDTH,
+from engine.robotlist import (RobotList, WIDTH as ROBOT_LIST_WIDTH,
                               COLOR as ROBOT_LIST_COLOR)
 from engine.util import can_see_walls
 
@@ -618,6 +618,7 @@ class Arena:
         if not pygame.get_init():
             pygame.init()
 
+        robot_list = RobotList()
         window_size = self.window_size
         viewport_size = self.viewport_size
         window = pygame.display.set_mode(window_size)
@@ -687,7 +688,7 @@ class Arena:
 
             # Draw Robot list
             ranked = [(r, p) for r, _, p in self.__rank_robots()]
-            render_robot_list(window, ranked, time_limit, self.total_sim_time)
+            robot_list.render(window, ranked, time_limit, self.total_sim_time)
 
             # Display results on window
             pygame.display.flip()

--- a/engine/entity/entity.py
+++ b/engine/entity/entity.py
@@ -25,6 +25,7 @@ class Entity:
 
         # Cached absolute hitbox, w/ position and rotation
         self.__cached_ah: tuple[list[Vector2], Vector2, float] | None = None
+        self.__cached_rect: tuple[Rect, Vector2, float] | None = None
 
     # Separate vector attributes into getter/setter to force copy on assign.
     # Otherwise, one could assign a position to an entity and then update that
@@ -73,6 +74,12 @@ class Entity:
     @property
     def rect(self) -> Rect:
         """Axis-aligned bounding rectangle of the entity."""
+        # Return cached rect if it exists and is in the same place
+        if self.__cached_rect is not None:
+            old_rect, old_position, old_rotation = self.__cached_rect
+            if old_position == self.position and old_rotation == self.rotation:
+                return old_rect
+
         min_x, min_y = math.inf, math.inf
         max_x, max_y = -math.inf, -math.inf
 
@@ -82,8 +89,12 @@ class Entity:
             max_x = max(max_x, point.x)
             max_y = max(max_y, point.y)
 
-        return Rect(Vector2(min_x, min_y),
+        rect = Rect(Vector2(min_x, min_y),
                     Vector2(max_x - min_x, max_y - min_y))
+
+        self.__cached_rect = (rect, self.position, self.rotation)
+
+        return rect
 
     @property
     def is_static(self) -> bool:

--- a/engine/entity/entity.py
+++ b/engine/entity/entity.py
@@ -23,6 +23,9 @@ class Entity:
         self.arena: Optional[arena.Arena] = None        # Containing Arena
         self.collision_filter: set[Entity] = set()      # No-collide set
 
+        # Cached absolute hitbox, w/ position and rotation
+        self.__cached_ah: tuple[list[Vector2], Vector2, float] | None = None
+
     # Separate vector attributes into getter/setter to force copy on assign.
     # Otherwise, one could assign a position to an entity and then update that
     # entity's position via the original vector value!
@@ -54,8 +57,18 @@ class Entity:
     @property
     def absolute_hitbox(self) -> list[Vector2]:
         """Absolute positions of entity hitbox vertices, in order."""
-        return [vertex.rotate_rad(self.rotation) + self.position
-                for vertex in self.hitbox]
+        # Return cached hitbox if it exists and is in the same place
+        if self.__cached_ah is not None:
+            old_hitbox, old_position, old_rotation = self.__cached_ah
+            if old_position == self.position and old_rotation == self.rotation:
+                return old_hitbox
+
+        hitbox = [vertex.rotate_rad(self.rotation) + self.position
+                  for vertex in self.hitbox]
+
+        self.__cached_ah = (hitbox, self.position, self.rotation)
+
+        return hitbox
 
     @property
     def rect(self) -> Rect:

--- a/engine/entity/entity.py
+++ b/engine/entity/entity.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pygame
 
 import engine.arena as arena
-from engine.util import check_polygon_collision, get_minimum_translation_vector
+import engine.util as util
 
 Rect = pygame.Rect
 Vector2 = pygame.Vector2
@@ -117,10 +117,10 @@ class Entity:
         self_hitbox = self.absolute_hitbox
         other_hitbox = other.absolute_hitbox
 
-        is_colliding = check_polygon_collision(self_hitbox, other_hitbox)
+        is_colliding = util.check_polygon_collision(self_hitbox, other_hitbox)
         if is_colliding:
-            translation = get_minimum_translation_vector(self_hitbox,
-                                                         other_hitbox)
+            translation = util.get_minimum_translation_vector(self_hitbox,
+                                                              other_hitbox)
             return True, translation
         else:
             return False, Vector2()

--- a/engine/entity/robot.py
+++ b/engine/entity/robot.py
@@ -4,10 +4,10 @@ from typing import Callable, Optional
 
 import pygame
 
-from engine.control import ControllerAction, ControllerState
+import engine.control as control
 import engine.entity as entity
 from engine.entity.bullet import BULLET_SPEED
-from engine.util import angle_difference
+import engine.util as util
 
 Rect = pygame.Rect
 Vector2 = pygame.Vector2
@@ -277,7 +277,7 @@ class Robot(entity.Entity):
 
         direction = point - self.position
         angle = math.atan2(direction.y, direction.x)
-        angle_diff = angle_difference(self.rotation, angle)
+        angle_diff = util.angle_difference(self.rotation, angle)
 
         if abs(angle_diff) < math.pi / 16:
             self.move_power = direction.magnitude() / (self.__move_speed * dt)
@@ -291,7 +291,7 @@ class Robot(entity.Entity):
             if dt == 0:
                 return
 
-            diff = angle_difference(self.rotation, angle_or_point)
+            diff = util.angle_difference(self.rotation, angle_or_point)
             self.turn_power = diff / (self.__turn_speed * dt)
         elif type(angle_or_point) is Vector2:
             direction = angle_or_point - self.position
@@ -306,7 +306,7 @@ class Robot(entity.Entity):
             if dt == 0:
                 return
 
-            diff = angle_difference(self.turret_rotation, angle_or_point)
+            diff = util.angle_difference(self.turret_rotation, angle_or_point)
             self.turret_turn_power = diff / (self.__turret_turn_speed * dt)
         elif type(angle_or_point) is Vector2:
             direction = angle_or_point - self.position
@@ -333,7 +333,7 @@ class Robot(entity.Entity):
         """
         print(f"[WARN ({self.name})]: {message}")
 
-    def perform_action(self, action: ControllerAction, dt: float):
+    def perform_action(self, action: control.ControllerAction, dt: float):
         """
         Sets the values of a ControllerAction to the Robot's values. Performs
         validation on the ControllerAction values.
@@ -418,8 +418,8 @@ class Robot(entity.Entity):
                         f"{action.shoot}; defaulting to False")
             self.__will_shoot = False
 
-    def compute_state(self, dt: float) -> ControllerState:
-        state = ControllerState()
+    def compute_state(self, dt: float) -> control.ControllerState:
+        state = control.ControllerState()
 
         state.time_delta = dt
 

--- a/engine/entity/wall.py
+++ b/engine/entity/wall.py
@@ -1,8 +1,11 @@
+import math
+
 import pygame
 
 import engine.entity as entity
 from engine.entity.robot import ROBOT_HITBOX_WIDTH
 
+Rect = pygame.Rect
 Vector2 = pygame.Vector2
 
 
@@ -42,6 +45,21 @@ class Wall(entity.Entity):
         ]
         return [vertex.rotate_rad(self.rotation) + self.position
                 for vertex in expanded]
+
+    @property
+    def pathfinding_rect(self) -> Rect:
+        """Axis-aligned bounding rectangle of the wall's pathfinding hitbox."""
+        min_x, min_y = math.inf, math.inf
+        max_x, max_y = -math.inf, -math.inf
+
+        for point in self.pathfinding_hitbox:
+            min_x = min(min_x, point.x)
+            min_y = min(min_y, point.y)
+            max_x = max(max_x, point.x)
+            max_y = max(max_y, point.y)
+
+        return Rect(Vector2(min_x, min_y),
+                    Vector2(max_x - min_x, max_y - min_y))
 
     @property
     def is_static(self) -> bool:

--- a/engine/entity/wall.py
+++ b/engine/entity/wall.py
@@ -17,24 +17,20 @@ class Wall(entity.Entity):
         self.rotation = rotation
         self.__size = size
 
-    @property
-    def hitbox(self) -> list[Vector2]:
+        # Compute hitboxes immediately since they are static
         half_size = self.__size / 2
-        return [
+        half_size_reflect = Vector2(half_size.x, -half_size.y)
+
+        self.__hitbox = [
             half_size,
             Vector2(half_size.x, -half_size.y),
             -half_size,
             Vector2(-half_size.x, half_size.y)
         ]
 
-    @property
-    def pathfinding_hitbox(self) -> list[Vector2]:
-        """
-        Hitbox of the Wall expanded by the Robot agent radius, in absolute
-        coordinates.
-        """
-        half_size = self.__size / 2
-        half_size_reflect = Vector2(half_size.x, -half_size.y)
+        self.__absolute_hitbox = [vertex.rotate_rad(self.rotation)
+                                  + self.position for vertex in self.__hitbox]
+
         robot_size = Vector2(ROBOT_HITBOX_WIDTH) / 2
         robot_size_reflect = Vector2(robot_size.x, -robot_size.y)
         expanded = [
@@ -43,8 +39,18 @@ class Wall(entity.Entity):
             -half_size - robot_size,
             -half_size_reflect - robot_size_reflect
         ]
-        return [vertex.rotate_rad(self.rotation) + self.position
-                for vertex in expanded]
+        self.pathfinding_hitbox = [vertex.rotate_rad(self.rotation)
+                                   + self.position for vertex in expanded]
+
+    @property
+    def hitbox(self) -> list[Vector2]:
+        # Return pre-computed hitbox
+        return self.__hitbox
+
+    @property
+    def absolute_hitbox(self) -> list[Vector2]:
+        # Return pre-computed absolute hitbox
+        return self.__absolute_hitbox
 
     @property
     def pathfinding_rect(self) -> Rect:

--- a/engine/entity/wall.py
+++ b/engine/entity/wall.py
@@ -17,7 +17,7 @@ class Wall(entity.Entity):
         self.rotation = rotation
         self.__size = size
 
-        # Compute hitboxes immediately since they are static
+        # Compute hitboxes and rects immediately since they are static
         half_size = self.__size / 2
         half_size_reflect = Vector2(half_size.x, -half_size.y)
 
@@ -42,6 +42,27 @@ class Wall(entity.Entity):
         self.pathfinding_hitbox = [vertex.rotate_rad(self.rotation)
                                    + self.position for vertex in expanded]
 
+        min_x, min_y = math.inf, math.inf
+        max_x, max_y = -math.inf, -math.inf
+
+        for point in self.__absolute_hitbox:
+            min_x = min(min_x, point.x)
+            min_y = min(min_y, point.y)
+            max_x = max(max_x, point.x)
+            max_y = max(max_y, point.y)
+
+        self.__rect = Rect(Vector2(min_x, min_y),
+                           Vector2(max_x - min_x, max_y - min_y))
+
+        for point in self.pathfinding_hitbox:
+            min_x = min(min_x, point.x)
+            min_y = min(min_y, point.y)
+            max_x = max(max_x, point.x)
+            max_y = max(max_y, point.y)
+
+        self.pathfinding_rect = Rect(Vector2(min_x, min_y),
+                                     Vector2(max_x - min_x, max_y - min_y))
+
     @property
     def hitbox(self) -> list[Vector2]:
         # Return pre-computed hitbox
@@ -53,19 +74,9 @@ class Wall(entity.Entity):
         return self.__absolute_hitbox
 
     @property
-    def pathfinding_rect(self) -> Rect:
-        """Axis-aligned bounding rectangle of the wall's pathfinding hitbox."""
-        min_x, min_y = math.inf, math.inf
-        max_x, max_y = -math.inf, -math.inf
-
-        for point in self.pathfinding_hitbox:
-            min_x = min(min_x, point.x)
-            min_y = min(min_y, point.y)
-            max_x = max(max_x, point.x)
-            max_y = max(max_y, point.y)
-
-        return Rect(Vector2(min_x, min_y),
-                    Vector2(max_x - min_x, max_y - min_y))
+    def rect(self) -> Rect:
+        # Return pre-computed rect
+        return self.__rect
 
     @property
     def is_static(self) -> bool:

--- a/engine/pathfinding.py
+++ b/engine/pathfinding.py
@@ -201,19 +201,21 @@ class PathfindingGraph:
 
     def get_visible_nodes(self, point: Vector2, rotation: Optional[float]):
         """Returns a list of up to 8 visible nodes, sorted by closeness."""
-        def sort_key(node: Node):
+        def cost(node: Node):
             if rotation is not None:
                 return evaluate_cost(point, rotation, node.position)
             else:
                 return (point - node.position).magnitude_squared()
 
-        sorted_nodes = sorted(self.__nodes, key=sort_key)
+        node_costs = [(cost(node), node) for node in self.__nodes]
+
+        sorted_nodes = sorted(node_costs)
 
         result = list[Node]()
         i = 0
 
         while (len(result) == 0 or i < 8) and i < len(sorted_nodes):
-            node = sorted_nodes[i]
+            _, node = sorted_nodes[i]
             if can_see_walls(point, node.position, self.__quadtree):
                 result.append(node)
             i += 1

--- a/engine/quadtree.py
+++ b/engine/quadtree.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
-from typing import Callable, Final, Optional
+import math
+from typing import Callable, Generic, Optional, TypeVar
 
 import pygame
-
-from engine.entity import Entity
 
 Rect = pygame.Rect
 Vector2 = pygame.Vector2
 
-Intersection = tuple[Entity, Entity]
+# Object type
+Object = TypeVar("Object")
+
+# Function to retrieve a Rect from an object
+ObjectToRect = Callable[[Object], Rect]
+# Function to retrieve a position from an object
+ObjectToPos = Callable[[Object], Vector2]
+
+# Intersection between two objects
+Intersection = tuple[Object, Object]
 
 # Predicate for nearest neighbor
-Predicate = Callable[[Entity], bool]
+Predicate = Callable[[Object], bool]
 
 
 def get_child_rect(rect: Rect, i: int) -> Rect:
@@ -87,23 +95,23 @@ def get_quadrant_from_point(node_rect: Rect, point: Vector2) -> int:
             return 3
 
 
-def closer(entity1: Optional[Entity], entity2: Optional[Entity], point: Vector2
-           ) -> Optional[Entity]:
+def closer(object1: Optional[Object], object2: Optional[Object],
+           point: Vector2, get_pos: ObjectToPos[Object]) -> Optional[Object]:
     """
-    Given two entities and a point, returns the entity closer to the point.
+    Given two objects and a point, returns the object closer to the point.
     """
-    if entity2 is None:
-        return entity1
-    if entity1 is None:
-        return entity2
+    if object2 is None:
+        return object1
+    if object1 is None:
+        return object2
 
-    point_to_entity = (entity1.position - point).magnitude()
-    point_to_closest = (entity2.position - point).magnitude()
+    point_to_object = (get_pos(object1) - point).magnitude()
+    point_to_closest = (get_pos(object2) - point).magnitude()
 
-    if point_to_entity < point_to_closest:
-        return entity1
+    if point_to_object < point_to_closest:
+        return object1
     else:
-        return entity2
+        return object2
 
 
 def distance_to_rect(point: Vector2, rect: Rect) -> float:
@@ -130,12 +138,12 @@ def distance_to_rect(point: Vector2, rect: Rect) -> float:
     return (dx * dx + dy * dy) ** 0.5
 
 
-class Node:
+class Node(Generic[Object]):
     """Node of a Quadtree."""
     def __init__(self):
-        self.entities: list[Entity] = []    # List of entities under this node
-        self.children: list[Node] = []      # List of 0 or 4 children nodes
-        self.threshold: Final[int] = 8      # Max size of self.entities
+        self.objects = list[Object]()           # List of objects in this node
+        self.children = list[Node[Object]]()    # List of 0 or 4 children nodes
+        self.threshold = 8                      # Max size of self.objects
 
     @property
     def is_leaf(self):
@@ -147,43 +155,43 @@ class Node:
         """A Node is a branch node if it has 4 children nodes."""
         return len(self.children) == 4
 
-    def remove_entity(self, entity: Entity):
+    def remove_object(self, object: Object):
         """
-        Removes an entity from this node. Specialized as a method to
+        Removes an object from this node. Specialized as a method to
         incorporate a swap-and-pop optimization.
         """
-        entities = self.entities
+        objects = self.objects
 
-        # The below will throw if the entity is not present, so an assert
+        # The below will throw if the object is not present, so an assert
         # would be extraneous.
-        index = entities.index(entity)
-        entities[index], entities[-1] = entities[-1], entities[index]
-        entities.pop()
+        index = objects.index(object)
+        objects[index], objects[-1] = objects[-1], objects[index]
+        objects.pop()
 
-    def split(self, rect: Rect):
+    def split(self, rect: Rect, get_rect: ObjectToRect[Object]):
         """
         Splits this leaf node into a branch node. Creates 4 child leaf nodes
-        and splits this node's entities among them and itself depending on
+        and splits this node's objects among them and itself depending on
         quadrant.
         """
         assert self.is_leaf, "Only leaf nodes can split"
 
         self.children = [Node() for i in range(4)]
 
-        new_self_entities = []
-        for entity in self.entities:
-            i = get_quadrant_from_rect(rect, entity.rect)
+        new_self_objects = []
+        for object in self.objects:
+            i = get_quadrant_from_rect(rect, get_rect(object))
             if i is not None:
-                self.children[i].entities.append(entity)
+                self.children[i].objects.append(object)
             else:
-                new_self_entities.append(entity)
+                new_self_objects.append(object)
 
-        self.entities = new_self_entities
+        self.objects = new_self_objects
 
     def try_merge(self) -> bool:
         """
         Attempts to merge this branch node into a leaf node. Fails if the total
-        number of entities in this node and its children is larger than the
+        number of objects in this node and its children is larger than the
         threshold.
 
         Returns `True` if succeeded, `False` otherwise.
@@ -193,127 +201,166 @@ class Node:
         are_children_leaves = all(child.is_leaf for child in self.children)
         assert are_children_leaves, "Children of this node much be leaf nodes"
 
-        num_children_entities = sum(len(child.entities)
-                                    for child in self.children)
-        num_entities = len(self.entities) + num_children_entities
+        num_children_objects = sum(len(child.objects)
+                                   for child in self.children)
+        num_objects = len(self.objects) + num_children_objects
 
-        if num_entities > self.threshold:
+        if num_objects > self.threshold:
             return False
 
-        self.entities += (entity
-                          for child in self.children
-                          for entity in child.entities)
+        self.objects += (object
+                         for child in self.children
+                         for object in child.objects)
         self.children = []
 
         return True
 
 
-class Quadtree:
+class Quadtree(Generic[Object]):
     """
     Quadtree class which assists with 2D spacial organization. It's like a
     binary tree for two dimensions!
     """
-    def __init__(self, rect: Rect):
-        self.__root_node: Node = Node()
+    def __init__(self, rect: Rect, get_rect: ObjectToRect[Object],
+                 get_pos: ObjectToPos[Object]):
+        self.__root_node = Node[Object]()
         self.__root_rect = rect
         self.__max_depth = 8
 
-    def __add_leaf(self, node: Node, rect: Rect, entity: Entity, depth: int):
-        """Adds entity to a leaf node."""
-        if depth >= self.__max_depth or len(node.entities) < node.threshold:
-            # Insert entity into this leaf node if it has space or is at max
+        self.__get_rect = get_rect
+        self.__get_pos = get_pos
+
+    @staticmethod
+    def from_objects(objects: list[Object], get_rect: ObjectToRect[Object],
+                     get_pos: ObjectToPos[Object]) -> Quadtree[Object]:
+        """Constructs a Quadtree with a list of objects."""
+        # Calculate Quadtree bounds
+        min_x, min_y = math.inf, math.inf
+        max_x, max_y = -math.inf, -math.inf
+
+        for object in objects:
+            rect = get_rect(object)
+            min_x = min(min_x, rect.left)
+            min_y = min(min_y, rect.top)
+            max_x = max(max_x, rect.right)
+            max_y = max(max_y, rect.bottom)
+
+        quadtree_top_left = Vector2(min_x, min_y)
+        quadtree_size = Vector2(max_x - min_x, max_y - min_y)
+
+        # Construct Quadtree
+        quadtree = Quadtree(Rect(quadtree_top_left, quadtree_size), get_rect,
+                            get_pos)
+        for object in objects:
+            quadtree.add(object)
+
+        return quadtree
+
+    def __add_leaf(self, node: Node[Object], rect: Rect, object: Object,
+                   depth: int):
+        """Adds object to a leaf node."""
+        if depth >= self.__max_depth or len(node.objects) < node.threshold:
+            # Insert object into this leaf node if it has space or is at max
             # depth
-            node.entities.append(entity)
+            node.objects.append(object)
         else:
             # Otherwise, split the node and try again
-            node.split(rect)
-            self.__add(node, rect, entity, depth)
+            node.split(rect, self.__get_rect)
+            self.__add(node, rect, object, depth)
 
-    def __add_branch(self, node: Node, rect: Rect, entity: Entity, depth: int):
-        """Adds entity to a branch node."""
-        i = get_quadrant_from_rect(rect, entity.rect)
+    def __add_branch(self, node: Node[Object], rect: Rect, object: Object,
+                     depth: int):
+        """Adds object to a branch node."""
+        i = get_quadrant_from_rect(rect, self.__get_rect(object))
         if i is not None:
-            # Add the entity in child node if entity is entirely contained in a
+            # Add the object in child node if object is entirely contained in a
             # quadrant
             child_node = node.children[i]
             child_rect = get_child_rect(rect, i)
-            self.__add(child_node, child_rect, entity, depth + 1)
+            self.__add(child_node, child_rect, object, depth + 1)
         else:
             # Add to current node otherwise
-            node.entities.append(entity)
+            node.objects.append(object)
 
-    def __add(self, node: Node, rect: Rect, entity: Entity, depth: int):
+    def __add(self, node: Node[Object], rect: Rect, object: Object,
+              depth: int):
         """Recursive helper function for Quadtree.add."""
         # TODO: Fix the rectangle calculation so that we can un-comment the
         # assert below. The Rect seems to have some rounding that causes it to
         # be a pixel or two short.
-        # assert rect.contains(entity.rect), "Entity must be within rect"
+        # assert rect.contains(self.__get_rect(object)), ("Object must be "
+        #                                                 "within rect")
 
         if node.is_leaf:
-            self.__add_leaf(node, rect, entity, depth)
+            self.__add_leaf(node, rect, object, depth)
         elif node.is_branch:
-            self.__add_branch(node, rect, entity, depth)
+            self.__add_branch(node, rect, object, depth)
         else:
             assert False, "Node is neither a leaf nor a branch"
 
-    def add(self, entity: Entity):
-        """Adds an entity to this Quadtree."""
-        self.__add(self.__root_node, self.__root_rect, entity, 0)
+    def add(self, object: Object):
+        """Adds an object to this Quadtree."""
+        self.__add(self.__root_node, self.__root_rect, object, 0)
 
-    def __remove_leaf(self, node: Node, rect: Rect, entity: Entity) -> bool:
-        """Removes an entity from a leaf node."""
-        # Remove entity from leaf node
-        node.remove_entity(entity)
+    def __remove_leaf(self, node: Node[Object], rect: Rect, object: Object
+                      ) -> bool:
+        """Removes an object from a leaf node."""
+        # Remove object from leaf node
+        node.remove_object(object)
         # Inform parent node to try to merge by returning True
         return True
 
-    def __remove_branch(self, node: Node, rect: Rect, entity: Entity) -> bool:
-        """Removes an entity from a branch node."""
-        i = get_quadrant_from_rect(rect, entity.rect)
+    def __remove_branch(self, node: Node[Object], rect: Rect, object: Object
+                        ) -> bool:
+        """Removes an object from a branch node."""
+        i = get_quadrant_from_rect(rect, self.__get_rect(object))
         if i is not None:
-            # Remove entity from child node if it's entirely contained in it
+            # Remove object from child node if it's entirely contained in it
             child_node = node.children[i]
             child_rect = get_child_rect(rect, i)
-            if self.__remove(child_node, child_rect, entity):
+            if self.__remove(child_node, child_rect, object):
                 # Try to merge if the child is a leaf node
                 return node.try_merge()
         else:
-            # Otherwise, remove the entity from the current node
-            node.remove_entity(entity)
+            # Otherwise, remove the object from the current node
+            node.remove_object(object)
         return False
 
-    def __remove(self, node: Node, rect: Rect, entity: Entity) -> bool:
+    def __remove(self, node: Node[Object], rect: Rect, object: Object) -> bool:
         """
         Recursive helper function for Quadtree.remove.
 
-        Returns `True` if `entity` was removed from a leaf node, `False`
+        Returns `True` if `object` was removed from a leaf node, `False`
         otherwise.
         """
         # TODO: Fix the rectangle calculation so that we can un-comment the
         # assert below. The Rect seems to have some rounding that causes it to
         # be a pixel or two short.
-        # assert rect.contains(entity.rect), "Entity must be within rect"
+        # assert rect.contains(self.__get_rect(object)), ("Object must be "
+        #                                                 "within rect")
 
         if node.is_leaf:
-            return self.__remove_leaf(node, rect, entity)
+            return self.__remove_leaf(node, rect, object)
         elif node.is_branch:
-            return self.__remove_branch(node, rect, entity)
+            return self.__remove_branch(node, rect, object)
         else:
             assert False, "Node is neither a leaf nor a branch"
 
-    def remove(self, entity: Entity):
-        """Removes an entity from this Quadtree."""
-        self.__remove(self.__root_node, self.__root_rect, entity)
+    def remove(self, object: Object):
+        """Removes an object from this Quadtree."""
+        self.__remove(self.__root_node, self.__root_rect, object)
 
-    def __query(self, node: Node, rect: Rect, query_rect: Rect,
-                entities: list[Entity]):
+    def __query(self, node: Node[Object], rect: Rect, query_rect: Rect,
+                objects: list[Object]):
         """Helper recursive function for Quadtree.query."""
+        if not query_rect.colliderect(rect):
+            print(query_rect, rect)
         assert query_rect.colliderect(rect)
 
-        # Add entities from this node that collide with the query_rect
-        entities += (entity
-                     for entity in node.entities
-                     if query_rect.colliderect(entity.rect))
+        # Add objects from this node that collide with the query_rect
+        objects += (object
+                    for object in node.objects
+                    if query_rect.colliderect(self.__get_rect(object)))
 
         if node.is_leaf:
             return
@@ -322,66 +369,70 @@ class Quadtree:
         for i, child in enumerate(node.children):
             child_rect = get_child_rect(rect, i)
             if query_rect.colliderect(child_rect):
-                self.__query(child, child_rect, query_rect, entities)
+                self.__query(child, child_rect, query_rect, objects)
 
-    def query(self, query_rect: Rect) -> list[Entity]:
-        """Queries for all entity rectangles intersecting a query rectangle."""
-        entities = []
-        self.__query(self.__root_node, self.__root_rect, query_rect, entities)
-        return entities
+    def query(self, query_rect: Rect) -> list[Object]:
+        """Queries for all object rectangles intersecting a query rectangle."""
+        objects = []
+        self.__query(self.__root_node, self.__root_rect, query_rect, objects)
+        return objects
 
-    def __find_intersections_in_descendants(self, node: Node, entity: Entity,
-                                            intersections: list[Intersection]):
+    def __find_intersections_in_descendants(self, node: Node[Object],
+                                            object: Object,
+                                            intersections:
+                                            list[Intersection[Object]]):
         """
-        Finds all intersections between an entity and all entities in the
+        Finds all intersections between an object and all objects in the
         provided node and its descendants.
         """
-        entity_rect = entity.rect
+        object_rect = self.__get_rect(object)
 
-        # Add the intersections between the entity and this node's entities
-        intersections += ((entity, other)
-                          for other in node.entities
-                          if entity_rect.colliderect(other.rect))
+        # Add the intersections between the object and this node's objects
+        intersections += ((object, other)
+                          for other in node.objects
+                          if object_rect.colliderect(self.__get_rect(other)))
 
         if node.is_leaf:
             return
 
         # Recurse
         for child in node.children:
-            self.__find_intersections_in_descendants(child, entity,
+            self.__find_intersections_in_descendants(child, object,
                                                      intersections)
 
-    def __find_all_intersections(self, node: Node,
-                                 intersections: list[Intersection]):
+    def __find_all_intersections(self, node: Node[Object],
+                                 intersections: list[Intersection[Object]]):
         """Recursive helper function for Quadtree.find_all_intersections."""
         intersections += (
-            (node.entities[i], node.entities[j])
-            for i in range(len(node.entities) - 1)
-            for j in range(i + 1, len(node.entities))
-            if node.entities[i].rect.colliderect(node.entities[j].rect)
+            (node.objects[i], node.objects[j])
+            for i in range(len(node.objects) - 1)
+            for j in range(i + 1, len(node.objects))
+            if (self.__get_rect(node.objects[i])
+                .colliderect(self.__get_rect(node.objects[j])))
         )
 
         if node.is_leaf:
             return
 
         for child in node.children:
-            for entity in node.entities:
-                self.__find_intersections_in_descendants(child, entity,
+            for object in node.objects:
+                self.__find_intersections_in_descendants(child, object,
                                                          intersections)
 
         for child in node.children:
             self.__find_all_intersections(child, intersections)
 
-    def find_all_intersections(self) -> list[Intersection]:
-        """Finds all pairs of rectangle intersections between two entities."""
+    def find_all_intersections(self) -> list[Intersection[Object]]:
+        """Finds all pairs of rectangle intersections between two objects."""
         intersections = []
         self.__find_all_intersections(self.__root_node, intersections)
         return intersections
 
-    def __nearest_neighbor(self, node: Node, rect: Rect, point: Vector2,
-                           predicate: Predicate) -> Optional[Entity]:
+    def __nearest_neighbor(self, node: Node[Object], rect: Rect,
+                           point: Vector2, predicate: Predicate[Object]
+                           ) -> Optional[Object]:
         """Recursive helper function for Quadtree.nearest_neighbor."""
-        closest: Optional[Entity] = None
+        closest: Optional[Object] = None
 
         if node.is_branch:
             # Get children rects
@@ -391,12 +442,13 @@ class Quadtree:
             children = sorted(children,
                               key=lambda t: distance_to_rect(point, t[1]))
 
-            # Check entities in children
+            # Check objects in children
             for i, child_rect in children:
                 if closest is not None:
                     # Prune child rects that are farther away than closest
                     point_to_rect = distance_to_rect(point, child_rect)
-                    point_to_closest = (closest.position - point).magnitude()
+                    point_to_closest = (self.__get_pos(closest)
+                                        - point).magnitude()
                     if point_to_rect >= point_to_closest:
                         # We break here since remaining child rects are farther
                         break
@@ -404,38 +456,38 @@ class Quadtree:
                 sub_closest = self.__nearest_neighbor(child_node,
                                                       child_rect, point,
                                                       predicate)
-                closest = closer(closest, sub_closest, point)
+                closest = closer(closest, sub_closest, point, self.__get_pos)
 
-        # Check entities in node
-        for entity in node.entities:
-            if not predicate(entity):
+        # Check objects in node
+        for object in node.objects:
+            if not predicate(object):
                 continue
-            closest = closer(closest, entity, point)
+            closest = closer(closest, object, point, self.__get_pos)
 
         return closest
 
-    def nearest_neighbor(self, point: Vector2, predicate: Predicate
-                         ) -> Optional[Entity]:
-        """Finds the nearest entity to a point that satisfies a predicate."""
+    def nearest_neighbor(self, point: Vector2, predicate: Predicate[Object]
+                         ) -> Optional[Object]:
+        """Finds the nearest object to a point that satisfies a predicate."""
         return self.__nearest_neighbor(self.__root_node, self.__root_rect,
                                        point, predicate)
 
-    def __render(self, screen: pygame.Surface, node: Node, rect: Rect):
+    def __render(self, screen: pygame.Surface, node: Node[Object], rect: Rect):
         """Recursive helper function for Quadtree.render."""
         pygame.draw.circle(screen, "#0000FF", Vector2(rect.center), 8)
 
-        for entity in node.entities:
+        for object in node.objects:
             pygame.draw.line(screen, "#0000FF", Vector2(rect.center),
-                             Vector2(entity.position))
+                             self.__get_pos(object))
 
-            entity_rect = entity.rect
+            object_rect = self.__get_rect(object)
             pygame.draw.lines(
                 screen, "#0000FF", True,
                 [
-                    Vector2(entity_rect.topleft),
-                    Vector2(entity_rect.topright),
-                    Vector2(entity_rect.bottomright),
-                    Vector2(entity_rect.bottomleft),
+                    Vector2(object_rect.topleft),
+                    Vector2(object_rect.topright),
+                    Vector2(object_rect.bottomright),
+                    Vector2(object_rect.bottomleft),
                 ]
             )
 

--- a/engine/quadtree.py
+++ b/engine/quadtree.py
@@ -29,21 +29,23 @@ def get_child_rect(rect: Rect, i: int) -> Rect:
 
     `i` must be one of `0`, `1`, `2`, or `3`.
     """
-    child_size = Vector2(rect.size) / 2
-    top_left = Vector2(rect.topleft)
+    x = rect.left
+    y = rect.top
+    w = rect.width / 2
+    h = rect.height / 2
 
     if i == 0:
         # Northwest
-        return Rect(top_left, child_size)
+        return Rect(x, y, w, h)
     elif i == 1:
         # Northeast
-        return Rect(top_left + Vector2(child_size.x, 0), child_size)
+        return Rect(x + w, y, w, h)
     elif i == 2:
         # Southwest
-        return Rect(top_left + Vector2(0, child_size.y), child_size)
+        return Rect(x, y + h, w, h)
     elif i == 3:
         # Southeast
-        return Rect(top_left + child_size, child_size)
+        return Rect(x + w, y + h, w, h)
     else:
         assert False, "i must be 0, 1, 2, or 3"
 

--- a/engine/robotlist.py
+++ b/engine/robotlist.py
@@ -120,6 +120,10 @@ def render_robot_list(surface: Surface, robots: list[tuple[Robot, int]],
 
     # Robot entries
     for robot, place in robots:
+        # Quit early if it won't be visible
+        if y >= surface.get_height():
+            break
+
         # Name (NH)
 
         # Name label max width (WIDTH - 2P - P - EH - 2P)

--- a/engine/robotlist.py
+++ b/engine/robotlist.py
@@ -44,25 +44,14 @@ def format_time(time: float) -> str:
 
 
 def render_robot_list(surface: Surface, robots: list[tuple[Robot, int]],
-                      time_limit: float, sim_time: float):
+                      time_limit: float, sim_time: float, coin: Coin,
+                      name_font: pygame.font.Font,
+                      stats_font: pygame.font.Font,
+                      title_font: pygame.font.Font):
     """
     Renders list of Robots on the left side of the window, along with other
     information.
     """
-    global coin
-
-    # Initialize Coin used for rendering an icon (yes this is hacky)
-    if coin is None:
-        coin = Coin(Vector2(COIN_RADIUS))
-
-    # Initialize fonts
-    name_font = pygame.font.SysFont(pygame.font.get_default_font(),
-                                    NAME_HEIGHT)
-    stats_font = pygame.font.SysFont(pygame.font.get_default_font(),
-                                     STATS_HEIGHT + 8)
-    title_font = pygame.font.SysFont(pygame.font.get_default_font(),
-                                     TITLE_HEIGHT)
-
     # Render the coin icon
     coin.update(1 / 60)
     coin_icon = Surface(Vector2(COIN_RADIUS * 2), flags=pygame.SRCALPHA)
@@ -223,3 +212,20 @@ def render_robot_list(surface: Surface, robots: list[tuple[Robot, int]],
 
         # Entry-to-entry padding (P)
         y += PADDING
+
+
+class RobotList:
+    def __init__(self):
+        self.name_font = pygame.font.SysFont(pygame.font.get_default_font(),
+                                             NAME_HEIGHT)
+        self.stats_font = pygame.font.SysFont(pygame.font.get_default_font(),
+                                              STATS_HEIGHT + 8)
+        self.title_font = pygame.font.SysFont(pygame.font.get_default_font(),
+                                              TITLE_HEIGHT)
+
+        self.coin = Coin(Vector2(COIN_RADIUS))
+
+    def render(self, surface: Surface, robots: list[tuple[Robot, int]],
+               time_limit: float, sim_time: float):
+        render_robot_list(surface, robots, time_limit, sim_time, self.coin,
+                          self.name_font, self.stats_font, self.title_font)

--- a/engine/robotlist.py
+++ b/engine/robotlist.py
@@ -148,8 +148,13 @@ def render_robot_list(surface: Surface, robots: list[tuple[Robot, int]],
                                     flags=pygame.SRCALPHA)
             robot.render_at_position(robot_surface, Vector2(ROBOT_RADIUS))
             ratio = ENTRY_HEIGHT / (2 * ROBOT_RADIUS)
-            robot_surface = pygame.transform.smoothscale_by(robot_surface,
-                                                            ratio)
+            if len(robots) <= 2:
+                robot_surface = pygame.transform.smoothscale_by(robot_surface,
+                                                                ratio)
+            else:
+                # Use normal scale_by to save on performance
+                robot_surface = pygame.transform.scale_by(robot_surface,
+                                                          ratio)
             surface.blit(robot_surface, robot_position)
         else:
             # If dead, show a big red X

--- a/engine/scenario/battleroyale.py
+++ b/engine/scenario/battleroyale.py
@@ -22,6 +22,7 @@ def battle_royale(controller_classes: list[type[Controller]],
         sys.exit("Invalid map; exiting")
 
     arena.show_fps = show_fps
+    arena.use_pathfinding = False
 
     for controller_class in controller_classes:
         # Initialize controller

--- a/engine/util/__init__.py
+++ b/engine/util/__init__.py
@@ -4,6 +4,7 @@ from engine.util.draw import draw_gradient_line as draw_gradient_line
 from engine.util.draw import draw_gradient_path as draw_gradient_path
 from engine.util.geometry import angle_difference as angle_difference
 from engine.util.geometry import can_see as can_see
+from engine.util.geometry import can_see_walls as can_see_walls
 from engine.util.geometry import check_polygon_collision as check_polygon_collision
 from engine.util.geometry import get_minimum_translation_vector as get_minimum_translation_vector
 from engine.util.geometry import is_point_in_polygon as is_point_in_polygon


### PR DESCRIPTION
Use `Quadtree` (which we generic-ified) to determine which segments to check for raycasting.

Precalculate `hitbox`, `absolute_hitbox`, `pathfinding_hitbox`, `rect`, and `pathfinding_rect` for `Wall`s since they are static.

Cache `absolute_hitbox` and `rect` for `Entity`s for the same position and rotation values.

Optimize the robot list by:
- Only initializing the fonts once (used a Class with an `__init__` for this)
- Stop rendering robot list entries after the y-cursor goes offscreen
- Use `scale_by` instead of `smoothscale_by` on the robot previews for large numbers of robots.

Optimize `get_child_rect` by reducing `Vector2` usage

Optimize sorting of `Node`s in `PathfindingGraph.get_visible_nodes` by precalculating the cost value for each node once; instead of providing the cost function as a sort key and having cost re-calculate many times.

Disable usage of `PathfindingGraph` for `battle_royale` scenario.